### PR TITLE
Pass on pixiewps exit code.

### DIFF
--- a/src/pixie.c
+++ b/src/pixie.c
@@ -26,8 +26,7 @@ void pixie_attack(void) {
 		p->pke, p->ehash1, p->ehash2, p->authkey, p->enonce,
 		dh_small ? "-S" : "-r" , dh_small ? "" : p->pkr);
 		printf("executing %s\n", cmd);
-		system(cmd);
-		exit(0);
+		exit(system(cmd));
 	}
 	PIXIE_FREE(authkey);
 	PIXIE_FREE(pkr);


### PR DESCRIPTION
pixie.c: In function 'pixie_attack':
pixie.c:29:3: warning: ignoring return value of 'system', declared with attribute warn_unused_result [-Wunused-result]
system(cmd);
^~~~~~~~~~~